### PR TITLE
2529-INFO_TABLES_QUERY_THRESHOLD-as-paramterer-from-config

### DIFF
--- a/dlt/common/destination/client.py
+++ b/dlt/common/destination/client.py
@@ -150,6 +150,9 @@ class DestinationClientConfiguration(BaseConfiguration):
     credentials: Optional[CredentialsConfiguration] = None
     destination_name: Optional[str] = None  # name of the destination
     environment: Optional[str] = None
+    info_tables_query_threshold: int = dataclasses.field(
+         default=1000
+     )  # threshold for info tables query, default to 1000
 
     def fingerprint(self) -> str:
         """Returns a destination fingerprint which is a hash of selected configuration fields. ie. host in case of connection string"""

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -252,8 +252,6 @@ class CopyRemoteFileLoadJob(RunnableLoadJob, HasFollowupJobs):
 
 
 class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
-    INFO_TABLES_QUERY_THRESHOLD: ClassVar[int] = 1000
-    """Fallback to querying all tables in the information schema if checking more than threshold"""
 
     def __init__(
         self,
@@ -262,6 +260,8 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
         sql_client: SqlClientBase[TNativeConn],
     ) -> None:
         # get definitions of the dlt tables, normalize column names and keep for later use
+        self.INFO_TABLES_QUERY_THRESHOLD = config.info_tables_query_threshold
+        """This gives priority to the value in `DestinationClientConfiguration` """
         version_table_ = normalize_table_identifiers(version_table(), schema.naming)
         self.version_table_schema_columns = ", ".join(
             sql_client.escape_column_name(col) for col in version_table_["columns"]


### PR DESCRIPTION
### Description
The pull request introduces a new configuration parameter (info_tables_query_threshold) to set the threshold for info tables queries in the DestinationClientConfiguration. This aims to make the query threshold dynamic and configurable, instead of using a hard-coded value.

### Related Issues

- Fixes [#2529](https://github.com/dlt-hub/dlt/issues/2529)

### Additional Context

Added the info_tables_query_threshold parameter in the DestinationClientConfiguration class in client.py.
Updated the SqlJobClientBase class (job_client_impl.py) to fetch and apply the threshold dynamically from the configuration during initialization. Ensured backward compatibility by setting a default threshold value of 1000.

